### PR TITLE
Add lasso and polygon selection tools to UMAP app

### DIFF
--- a/xc_scripts/umap_app.py
+++ b/xc_scripts/umap_app.py
@@ -3,6 +3,8 @@
 UMAP Yellowhammer Visualization with Interactive Zoom
 Bokeh Server Application - COMPLETE VERSION
 
+Interactive plots expose box, lasso, and polygon selection tools for filtering points.
+
 To run:
 1. Save this file as 'xc_scripts/umap_app.py'
 2. Start audio server in separate terminal:
@@ -61,6 +63,7 @@ from bokeh.io import curdoc
 from bokeh.layouts import column, row
 from bokeh.models import (
     ColumnDataSource, Button, Div, DateRangeSlider, HoverTool, BoxSelectTool,
+    LassoSelectTool, PolySelectTool,
     TapTool, Toggle, Select, CheckboxGroup, CustomJS, RangeSlider, CDSView, BooleanFilter,
     Spinner
 )
@@ -611,16 +614,20 @@ def create_umap_plot(source):
         border_fill_color="#ffe88c"
     )
     
-    # Add box select tool
+    # Add selection tools (box default plus lasso/polygon for freeform filtering)
     box_select = BoxSelectTool()
-    p.add_tools(box_select)
+    lasso_select = LassoSelectTool()
+    poly_select = PolySelectTool()
+    p.add_tools(box_select, lasso_select, poly_select)
     p.toolbar.active_drag = box_select
     
     # Filter selections to only include visible points
     selection_filter_callback = CustomJS(args=dict(source=source), code="""
         const indices = source.selected.indices;
-        if (indices.length === 0) return;
-        
+        if (!indices || indices.length === 0) {
+            return;
+        }
+
         const alpha = source.data['alpha'];
         const filtered = [];
         
@@ -698,7 +705,14 @@ def create_map_plot(source):
         background_fill_color="#ffe88c",
         border_fill_color="#ffe88c"
     )
-    
+
+    # Mirror selection tools from the UMAP plot for consistent interactions
+    map_box_select = BoxSelectTool()
+    map_lasso_select = LassoSelectTool()
+    map_poly_select = PolySelectTool()
+    map_fig.add_tools(map_box_select, map_lasso_select, map_poly_select)
+    map_fig.toolbar.active_drag = map_box_select
+
     try:
         map_fig.add_tile("CartoDB Positron", retina=True)
     except:


### PR DESCRIPTION
## Summary
- add lasso and polygon selection tools to both the UMAP scatter plot and geographic map
- update selection filtering callback to guard against empty selections from new tools
- document the expanded selection options in the app instructions

## Testing
- python -m compileall xc_scripts/umap_app.py

------
https://chatgpt.com/codex/tasks/task_e_68ee60c63e4c832390e8846fb40c3b0e