### PR TITLE
fixed spectrogram loading

### DIFF
--- a/xc_configs/config.yaml
+++ b/xc_configs/config.yaml
@@ -44,5 +44,15 @@ analysis:
   point_alpha: 0.3          # Transparency of points (0.0-1.0)
 
 audio:
-  base_url: "http://localhost:8765"  # Base URL for audio server
-  port: 8765                          # Port for local audio server
+  auto_serve: true                   # Start lightweight HTTP server for clips
+  host: "127.0.0.1"                  # Bind address for audio server
+  port: 8765                         # Port for local audio server
+  base_url: null                     # Override to use an existing server instead
+
+spectrograms:
+  auto_serve: true                   # Start a lightweight HTTP server from the app
+  host: "127.0.0.1"                  # Bind address for serving spectrogram PNGs
+  port: 8766                         # Port for spectrogram server
+  base_url: null                     # Override to use an existing server instead
+  image_format: "png"                # Spectrogram file extension
+  inline: false                      # Use HTTP delivery rather than embedding base64

--- a/xc_configs/config_chloris_chloris.yaml
+++ b/xc_configs/config_chloris_chloris.yaml
@@ -44,5 +44,15 @@ analysis:
   point_alpha: 0.3          # Transparency of points (0.0-1.0)
 
 audio:
-  base_url: "http://localhost:8765"  # Base URL for audio server
-  port: 8765                          # Port for local audio server
+  auto_serve: true                   # Start lightweight HTTP server for clips
+  host: "127.0.0.1"                  # Bind address for audio server
+  port: 8765                         # Port for local audio server
+  base_url: null                     # Override to use an existing server instead
+
+spectrograms:
+  auto_serve: true                   # Start a lightweight HTTP server from the app
+  host: "127.0.0.1"                  # Bind address for serving spectrogram PNGs
+  port: 8766                         # Port for spectrogram server
+  base_url: null                     # Override to use an existing server instead
+  image_format: "png"                # Spectrogram file extension
+  inline: false                      # Use HTTP delivery rather than embedding base64

--- a/xc_configs/config_limosa_limosa.yaml
+++ b/xc_configs/config_limosa_limosa.yaml
@@ -44,5 +44,15 @@ analysis:
   point_alpha: 0.3          # Transparency of points (0.0-1.0)
 
 audio:
-  base_url: "http://localhost:8765"  # Base URL for audio server
-  port: 8765                          # Port for local audio server
+  auto_serve: true                   # Start lightweight HTTP server for clips
+  host: "127.0.0.1"                  # Bind address for audio server
+  port: 8765                         # Port for local audio server
+  base_url: null                     # Override to use an existing server instead
+
+spectrograms:
+  auto_serve: true                   # Start a lightweight HTTP server from the app
+  host: "127.0.0.1"                  # Bind address for serving spectrogram PNGs
+  port: 8766                         # Port for spectrogram server
+  base_url: null                     # Override to use an existing server instead
+  image_format: "png"                # Spectrogram file extension
+  inline: false                      # Use HTTP delivery rather than embedding base64


### PR DESCRIPTION
Fixed an issue where spectrogram loading would slow the app to the point of crashing. Now, spectrograms are served on demand by an automatically generated server. This improves initial loading times, and causes no waiting times when populating playlist window. Audio is now also served from an automatically created server.